### PR TITLE
1. Libreoffice workaround; 2. unused code commented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 ![Demo](data/preview.png)
 
+# Build instructions for Plasma 6
+```
+mkdir build
+cd build
+cmake .. -DQT_MAJOR_VERSION=6 -DQT_VERSION_MAJOR=6
+make
+sudo cp ./src/materialdecoration.so /usr/lib/qt6/plugins/org.kde.kdecoration2/materialdecoration.so
+```
+
 ## material-decoration
 
 Material-ish window decoration theme for KWin.

--- a/src/AppMenuButtonGroup.cc
+++ b/src/AppMenuButtonGroup.cc
@@ -500,7 +500,7 @@ bool AppMenuButtonGroup::eventFilter(QObject *watched, QEvent *event)
 
         const auto *deco = qobject_cast<Decoration *>(decoration());
 
-        QPoint decoPos(e->globalPos());
+        QPoint decoPos(e->globalPosition().toPoint());
         decoPos -= deco->windowPos();
         decoPos.ry() += deco->titleBarHeight();
         // qCDebug(category) << "MouseMove";

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -200,7 +200,7 @@ void AppMenuModel::setWinId(const QVariant &id)
     if (m_winId == id) {
         return;
     }
-    qCDebug(category) << "AppMenuModel::setWinId" << m_winId << " => " << id;
+    // qCDebug(category) << "AppMenuModel::setWinId" << m_winId << " => " << id;
     m_winId = id;
     emit winIdChanged();
 }
@@ -293,7 +293,7 @@ void AppMenuModel::onWinIdChanged()
                 updateApplicationMenu(serviceName, menuObjectPath);
                 // if it is libreoffice we need to monitor it 
                 if (winClass.contains ("soffice.bin"))   {
-                       qCDebug(category) << winClass << " Great Scott! it's LibreOffice, we need to monitor it!";
+                       // qCDebug(category) << winClass << " Great Scott! it's LibreOffice, we need to monitor it!";
                        qApp->removeNativeEventFilter(this);
                        qApp->installNativeEventFilter(this);
                        m_delayedMenuWindowId = id;

--- a/src/AppMenuModel.cc
+++ b/src/AppMenuModel.cc
@@ -133,12 +133,16 @@ void AppMenuModel::x11Init()
 
 // In KF5 5.101, KWindowSystem moved several signals to KX11Extras
 // Eg: https://invent.kde.org/frameworks/kwindowsystem/-/commit/7cfd7c36eb017242d7a0202db82895be6b8fb81c
+
+
 #if HAVE_KF5_101 // KX11Extras
     // Select non-deprecated overloaded method. Uses coding pattern from:
     // https://invent.kde.org/plasma/plasma-workspace/blame/master/libtaskmanager/xwindowsystemeventbatcher.cpp#L30
+    /* UNUSED
     void (KX11Extras::*myWindowChangeSignal)(WId window, NET::Properties properties, NET::Properties2 properties2) = &KX11Extras::windowChanged;
     connect(KX11Extras::self(), myWindowChangeSignal,
             this, &AppMenuModel::onX11WindowChanged);
+    */        
 
     // There are apps that are not releasing their menu properly after closing
     // and as such their menu is still shown even though the app does not exist
@@ -146,12 +150,16 @@ void AppMenuModel::x11Init()
     connect(KX11Extras::self(), &KX11Extras::windowRemoved,
             this, &AppMenuModel::onX11WindowRemoved);
 #else // KF5 5.100 KWindowSystem
+    /* UNUSED
     void (KWindowSystem::*myWindowChangeSignal)(WId window, NET::Properties properties, NET::Properties2 properties2) = &KWindowSystem::windowChanged;
     connect(KWindowSystem::self(), myWindowChangeSignal,
             this, &AppMenuModel::onX11WindowChanged);
+    */
     connect(KWindowSystem::self(), &KWindowSystem::windowRemoved,
             this, &AppMenuModel::onX11WindowRemoved);
 #endif
+    
+
 
     connect(this, &AppMenuModel::modelNeedsUpdate, this, [this] {
         if (!m_updatePending) {
@@ -279,9 +287,17 @@ void AppMenuModel::onWinIdChanged()
         auto updateMenuFromWindowIfHasMenu = [this, &getWindowPropertyString](WId id) {
             const QString serviceName = QString::fromUtf8(getWindowPropertyString(id, s_x11AppMenuServiceNamePropertyName));
             const QString menuObjectPath = QString::fromUtf8(getWindowPropertyString(id, s_x11AppMenuObjectPathPropertyName));
+            const QString winClass = QString::fromUtf8(getWindowPropertyString(id, "WM_CLASS"));
 
             if (!serviceName.isEmpty() && !menuObjectPath.isEmpty()) {
                 updateApplicationMenu(serviceName, menuObjectPath);
+                // if it is libreoffice we need to monitor it 
+                if (winClass.contains ("soffice.bin"))   {
+                       qCDebug(category) << winClass << " Great Scott! it's LibreOffice, we need to monitor it!";
+                       qApp->removeNativeEventFilter(this);
+                       qApp->installNativeEventFilter(this);
+                       m_delayedMenuWindowId = id;
+                };  
                 return true;
             }
 
@@ -309,12 +325,14 @@ void AppMenuModel::onWinIdChanged()
     }
 }
 
+/* UNUSED, remove
 void AppMenuModel::onX11WindowChanged(WId id)
 {
     if (m_winId.toUInt() == id) {
         
     }
 }
+*/
 
 void AppMenuModel::onX11WindowRemoved(WId id)
 {

--- a/src/AppMenuModel.h
+++ b/src/AppMenuModel.h
@@ -80,7 +80,7 @@ protected:
 
 private Q_SLOTS:
     void onWinIdChanged();
-    void onX11WindowChanged(WId id);
+    // void onX11WindowChanged(WId id); // UNUSED, remove 
     void onX11WindowRemoved(WId id);
 
     void update();

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -564,7 +564,7 @@ void Decoration::updateShadow()
     const int shadowStrengthInt = m_internalSettings->shadowStrength();
     const int shadowSizePreset = m_internalSettings->shadowSize();
 
-    if (!s_cachedShadow
+    if (s_cachedShadow
         && s_shadowColor == shadowColor
         && s_shadowSizePreset == shadowSizePreset
         && s_shadowStrength == shadowStrengthInt

--- a/src/Decoration.cc
+++ b/src/Decoration.cc
@@ -336,7 +336,7 @@ void Decoration::hoverMoveEvent(QHoverEvent *event)
     KDecoration2::Decoration::hoverMoveEvent(event);
     // qCDebug(category) << "Decoration::hoverMoveEvent" << event;
 
-    const bool dragStarted = dragMoveTick(event->pos());
+    const bool dragStarted = dragMoveTick(event->position().toPoint());
     // qCDebug(category) << "    " << "dragStarted" << dragStarted;
     if (dragStarted) {
         m_menuButtons->unPressAllButtons();


### PR DESCRIPTION
1. We try to work around the problem of LibreOffice not updating the menu when switching from starcenter to an application. We reuse the `NativeEventFilter` (already in the code for those applications that open but announce the menu later, e.g. Firefox).
In this case it doesn't work because the starcenter announces the menu and so the filter is not installed. 
So, we install it if the window class contains `soffice.bin`. 

2. `onX11WindowChanged(WId id)` is never used and is in fact empty. We comment the code instead of deleting it, in case it might be useful in the future.


